### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -41,8 +41,8 @@ cursor_off	KEYWORD2
 setBacklight	KEYWORD2
 load_custom_character	KEYWORD2
 printstr	KEYWORD2
-printHangul KEYWORD2
-setDelayTime KEYWORD2
+printHangul	KEYWORD2
+setDelayTime	KEYWORD2
 ###########################################
 # Constants (LITERAL1)
 ###########################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords